### PR TITLE
Add service for sticker popularity tracking and Flickr searches

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -66,6 +66,15 @@
             "localRoot": "${workspaceRoot}/sessionService",
             "remoteRoot": "/app/",
             "restart": true
+        },
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach (sticker service)",
+            "port": 5959,
+            "localRoot": "${workspaceRoot}/stickerService/",
+            "remoteRoot": "/app/",
+            "restart": true
         }
     ]
 }

--- a/stickerService/Dockerfile.dev
+++ b/stickerService/Dockerfile.dev
@@ -1,0 +1,5 @@
+FROM node:7.9.0-alpine
+RUN npm install -g nodemon
+WORKDIR /app
+ADD package.json .
+RUN npm install

--- a/stickerService/debug.env
+++ b/stickerService/debug.env
@@ -1,0 +1,9 @@
+KAFKA_HOST=zookeeper:2181
+KAFKA_TOPIC=TrendingStickers
+MONGO_URL=mongodb://mongo:27017/getStickersDemo
+NODE_ENV=development
+PORT=2000
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_PASSWORD=
+REDIS_TLS=

--- a/stickerService/docker-compose.dev.yml
+++ b/stickerService/docker-compose.dev.yml
@@ -1,0 +1,49 @@
+version: '2'
+
+services:
+  mongo-stickers:
+    image: mongo:3.5.5
+    ports:
+    - 27017:27017
+
+  sticker-service:
+    depends_on:
+    - kafka
+    - mongo-stickers
+    - redis
+    build:
+      context: ${PROJECT_ROOT}/stickerService
+      dockerfile: Dockerfile.dev
+    container_name: sticker-service
+    env_file:
+    - debug.env
+    command: nodemon --debug=0.0.0.0:5959 --legacy-watch index.js
+    ports:
+    - 2000:2000
+    - 5959:5959
+    volumes:
+    - ${PROJECT_ROOT}/stickerService:/app:ro
+    - /app/node_modules
+
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+    - 2181:2181
+
+  kafka:
+    depends_on:
+    - zookeeper
+    image: wurstmeister/kafka
+    ports:
+    - 9092:9092
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_CREATE_TOPICS: TrendingStickers:1:1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+
+  redis:
+    image: redis:3.2.8-alpine
+    ports:
+    - 6379:6379

--- a/stickerService/index.js
+++ b/stickerService/index.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const express = require('express');
+const app = express();
+const server = require('http').createServer(app);
+const io = require('socket.io')(server);
+const itemPopularity = require('./itemPopularity');
+
+const search = require('./routes/search');
+const stickers = require('./routes/stickers');
+const top = require('./routes/top');
+
+if (app.get('env') === 'development') {
+    const db = require('./mongodb');
+    const path = require('path');
+    const test = require('./routes/test');
+
+    // give the db some time to get ready, then initialize it with some data
+    // TODO use the gulp task for this (in an init container perhaps)
+    setTimeout(() => db.initializeDatabaseAsync()
+        .then(console.log('db initialized with seed data')), 20000);
+
+    app.use(express.static(path.join(__dirname, 'test')));
+    app.use('/test', test);
+}
+
+app.use('/search', search);
+app.use('/stickers', stickers);
+app.use('/top', top);
+
+// websocket stuff: send the current top items to all new connections,
+// and update everyone when the top items change
+io.on('connection', function sendTrendingItems(socket) {
+    console.log(`new socket ${socket.id} connected from ${socket.client.conn.remoteAddress}`);
+    itemPopularity.topKAsync(5)
+        .then(top5 => socket.send(top5))
+        .catch(error => console.log(`sending top items failed: ${error}`));
+});
+itemPopularity.on('newTopItems', topItems => io.send(topItems));
+
+server.listen(process.env.PORT, () => {
+    console.log(`Sticker service listening on ${server.address().port}`);
+});

--- a/stickerService/initial-data.js
+++ b/stickerService/initial-data.js
@@ -1,0 +1,170 @@
+module.exports = [
+
+    {
+        id: '1',
+        tags: [ 'Deployment' ],
+        name: 'Docker',
+        description: 'The Docker container-based platform deployment system',
+        author: 'Docker',
+        size: {
+            width: '2in',
+            height: '2in'
+        },
+        image: '/img/logo/docker.png'
+    }, {
+        id: '2',
+        tags: [ 'Service' ],
+        name: 'Trello',
+        description: 'The Trello project management service',
+        author: 'Trello',
+        size: {
+            width: '2in',
+            height: '2in'
+        },
+        image: '/img/logo/trello.png'
+    }, {
+        id: '3',
+        tags: [ 'Framework' ],
+        name: 'Ember',
+        description: 'The Ember JavaScript framework',
+        author: 'Ember',
+        size: {
+            width: '2in',
+            height: '2in'
+        },
+        image: '/img/logo/ember.png'
+    }, {
+        id: '4',
+        tags: [ 'Language' ],
+        name: 'Go',
+        description: 'The Go programming langauge',
+        author: 'Google',
+        size: {
+            width: '2in',
+            height: '2in'
+        },
+        image: '/img/logo/go.png'
+    }, {
+        id: '5',
+        tags: [ 'Language' ],
+        name: 'TypeScript',
+        description: 'The TypeScript programming langauge',
+        author: 'Microsoft',
+        size: {
+            width: '2in',
+            height: '2in'
+        },
+        image: '/img/logo/typescript.png'
+    }, {
+        id: '6',
+        tags: [ 'Tooling' ],
+        name: 'Git',
+        description: 'The Git version control system',
+        author: 'Git',
+        size: {
+            width: '2in',
+            height: '2in'
+        },
+        image: '/img/logo/git.png'
+    }, {
+        id: '7',
+        tags: [ 'Language' ],
+        name: 'Markdown',
+        description: 'The Markdown document language',
+        author: 'Markdown',
+        size: {
+            width: '2in',
+            height: '2in'
+        },
+        image: '/img/logo/markdown.png'
+    }, {
+        id: '8',
+        tags: [ 'Deployment' ],
+        name: 'Travis CI',
+        description: 'The Travis CI integration service',
+        author: 'Travis CI',
+        size: {
+            width: '2in',
+            height: '2in'
+        },
+        image: '/img/logo/travisci.png'
+    }, {
+        id: '9',
+        tags: [ 'Deployment' ],
+        name: 'Kubernetes',
+        description: 'The Kubernetes container deployment system',
+        author: 'Kubernetes',
+        size: {
+            width: '2in',
+            height: '2in'
+        },
+        image: '/img/logo/kubernetes.png'
+    }, {
+        id: '10',
+        tags: [ 'Protocol' ],
+        name: 'OAuth',
+        description: 'The OAuth authentication protocol',
+        author: 'OAuth',
+        size: {
+            width: '2in',
+            height: '2in'
+        },
+        image: '/img/logo/oauth.png'
+    }, {
+        id: '11',
+        tags: [ 'Service' ],
+        name: 'MailChimp',
+        description: 'MailChimp provides email marketing services',
+        author: 'MailChimp',
+        size: {
+            width: '2in',
+            height: '2in'
+        },
+        image: '/img/logo/mailchimp.png'
+    }, {
+        id: '12',
+        tags: [ 'Framework' ],
+        name: 'Bootstrap',
+        description: 'The Bootstrap CSS client framework',
+        author: 'Twitter',
+        size: {
+            width: '2in',
+            height: '2in'
+        },
+        image: '/img/logo/bootstrap.png'
+    }, {
+        id: '13',
+        tags: [ 'Language' ],
+        name: 'Rust',
+        description: 'The Rust programming langauge',
+        author: 'Mozilla',
+        size: {
+            width: '2in',
+            height: '2in'
+        },
+        image: '/img/logo/rust.png'
+    }, {
+        id: '14',
+        tags: [ 'Service' ],
+        name: 'Open Source Initiative',
+        description: 'The Open Source Initiative non-profit foundation',
+        author: 'OSI',
+        size: {
+            width: '2in',
+            height: '2in'
+        },
+        image: '/img/logo/osi.png'
+    }, {
+        id: '15',
+        tags: [ 'Language' ],
+        name: 'Ruby',
+        description: 'The Ruby programming langauge',
+        author: 'Ruby Community',
+        size: {
+            width: '2in',
+            height: '2in'
+        },
+        image: '/img/logo/ruby.png'
+    }
+
+];

--- a/stickerService/itemPopularity.js
+++ b/stickerService/itemPopularity.js
@@ -1,0 +1,202 @@
+'use strict';
+
+// This module tracks item popularity. It watches a Kafka topic for checkout
+// and item view events. It uses these events to calculate a popularity score,
+// persisted in Redis, for each item. A higher score indicates greater popularity.
+// Scores are weighted toward orders: one order is worth three views. Also,
+// recent activity has more weight than past activity: scores decay over time.
+
+const events = require('events');
+const kafka = require('kafka-node');
+const redis = require('redis');
+const db = require('./mongodb');
+
+const eventEmitter = new events.EventEmitter();
+exports.on = (event, listener) => eventEmitter.on(event, listener);
+
+const REDIS_KEY = 'items:popularityscores';
+const redisClient = redis.createClient({
+    host: process.env.REDIS_HOST,
+    port: process.env.REDIS_PORT,
+    password: process.env.REDIS_PASSWORD || undefined,
+    tls: process.env.REDIS_TLS,
+    retry_strategy: options => {
+        // retry every 2 seconds for 10 seconds; crash, if that doesn't suffice
+        if (options.total_retry_time < 10 * 1000) {
+            console.log(`${options.error}, retrying...`);
+            return 2000;
+        }
+
+        throw `can't connect to redis`;
+    }
+});
+redisClient.on('error', err => {
+    // swallow errors to allow retries as specified in the retry_strategy above
+    console.log(`redis client error ${err}`);
+});
+redisClient.on('ready', () => {
+    console.log('redis client ready');
+    setInterval(decayScores, 60 * 1000);
+});
+
+exports.topKAsync = (k, withScores) => {
+    // returns the top k highest-scoring items
+    return new Promise((resolve, reject) => {
+        let args = [REDIS_KEY, 0, k];
+        if (withScores === true) {
+            args.push('withscores');
+        }
+
+        redisClient.zrevrange(args, async (error, itemIds) => {
+            if (error) {
+                return reject(error);
+            }
+            // we want the stickers ordered by descending score, but the
+            // database doesn't track scores, so we have to sort here
+            const stickers = await db.getStickersAsync(null, itemIds);
+            const sorted = stickers.sort((a, b) =>
+                itemIds.indexOf(a.id) - itemIds.indexOf(b.id)
+            );
+            resolve(sorted);
+        });
+    });
+};
+
+function decayScores() {
+    // retrieve all item ids with score >= 1
+    redisClient.zrangebyscore([REDIS_KEY, 1, '+inf', 'withscores'], (err, result) => {
+        if (err || result.length === 0) {
+            return;
+        }
+
+        let messages = ['decaying popularity scores'];
+        let newScores = [];
+        // zrangebyscore withscores returns [itemId, score, ...]
+        for (let i = 0; i < result.length; i += 2) {
+            const itemId = result[i];
+            const oldScore = result[i + 1];
+            const newScore = oldScore * 0.8;
+            // zadd expects [score, itemId, ...], the reverse of zrangebyscore's ordering
+            newScores.push(newScore, itemId);
+            messages.push(`  ${itemId}: ${oldScore} -> ${newScore}`);
+        }
+
+        redisClient.zadd([REDIS_KEY, ...newScores], (err, result) => {
+            if (err) {
+                messages.push(`  score update failed: ${err}`);
+            } else {
+                messages.push('  done');
+            }
+            console.log(messages.join('\n'));
+        });
+    });
+};
+
+function increaseItemScoreAsync(itemId, increaseAmount) {
+    return new Promise((resolve, reject) => {
+        redisClient.zincrby([REDIS_KEY, increaseAmount, itemId], (error, newScore) => {
+            if (error) {
+                reject(error);
+            } else {
+                resolve(`${itemId} score: ${newScore - increaseAmount} -> ${newScore}`);
+            }
+        });
+    });
+};
+
+// we expect msg.value is JSON for this:
+// [ { "item_id": string, "quantity": number? }, ... ]
+// where "quantity" is undefined for view events
+const messageMalformed = offset => `message at offset ${offset} is malformed`;
+function validateMessage(message) {
+    return new Promise((resolve, reject) => {
+        let parsedMessage;
+        try {
+            parsedMessage = JSON.parse(message.value);
+        } catch (ex) {
+            return reject(messageMalformed(message.offset));
+        }
+
+        let events = [];
+        for (const element of parsedMessage) {
+            if (!element.item_id) {
+                return reject(messageMalformed(message.offset));
+            }
+
+            let event = { item_id: element.item_id };
+            if (element.quantity) {
+                const quantity = parseInt(element.quantity);
+                if (!Number.isInteger(quantity)) {
+                    return reject(messageMalformed(message.offset));
+                }
+                event.quantity = quantity;
+            }
+
+            events.push(event);
+        }
+        resolve(events);
+    });
+}
+
+function topItemsChanged(a, b) {
+    if (a.length !== b.length) {
+        return true;
+    }
+
+    for (let i = 0; i < a.length; ++i) {
+        if (a[i].id !== b[i].id) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+async function handleMessage(msg) {
+    const items = await validateMessage(msg);
+    const priorTopItems = await exports.topKAsync(5);
+
+    // increase item scores
+    const scoreMessages = await Promise.all(items.map(item => {
+        // arbitrary multiplier: 1 order is worth 3 views
+        // (item.quantity is undefined for view events)
+        const scoreIncrement = item.quantity ? item.quantity * 3 : 1;
+        return increaseItemScoreAsync(item.item_id, scoreIncrement);
+    }));
+    console.log(scoreMessages.join('\n'));
+
+    const newTopItems = await exports.topKAsync(5);
+    if (topItemsChanged(newTopItems, priorTopItems)) {
+        eventEmitter.emit('newTopItems', newTopItems);
+    }
+}
+
+// this consumer reacts to item views and checkouts
+const KAFKA_TOPIC = process.env.KAFKA_TOPIC;
+const kafkaConsumer = new kafka.Consumer(
+    new kafka.Client(process.env.KAFKA_HOST),
+    [{ topic: KAFKA_TOPIC }]
+);
+kafkaConsumer.on('error', error => {
+    console.log(`kafkaConsumer error: ${error}`);
+    if (error.name === 'TopicsNotExistError') {
+        // when using docker-compose we may try to connect before the
+        // kafka container creates the topic--try again in 10 seconds
+        kafkaConsumer.removeTopics([KAFKA_TOPIC], (error, numberRemoved) => {
+            console.log('... retrying in 10 seconds');
+            setTimeout(() => {
+                kafkaConsumer.addTopics([KAFKA_TOPIC], (error, added) => {
+                    if (error) { throw error; }
+                    console.log(`... added topic ${added}`);
+                })
+            }, 10000);
+        });
+    }
+});
+kafkaConsumer.on('message', async msg => {
+    try {
+        await handleMessage(msg);
+    } catch (error) {
+        console.error('error handling Kafka message', error);
+    }
+});

--- a/stickerService/mongodb.js
+++ b/stickerService/mongodb.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const { MongoClient } = require('mongodb');
+
+const url = process.env.MONGO_URL;
+const stickerCollectionName = 'stickers';
+
+let connection;
+function connect() {
+    if (!connection) {
+        return MongoClient.connect(url).then(db => {
+            connection = db;
+            return connection;
+        });
+    }
+
+    return Promise.resolve(connection);
+}
+
+function disconnect() {
+    if (connection) {
+        return connection.close().then(() => {
+            connection = null;
+        });
+    }
+
+    return Promise.resolve();
+}
+
+function findDoc(db, collectionName, criteria) {
+    return db.collection(collectionName).findOne(criteria);
+}
+
+function findDocs(db, collectionName, criteria) {
+    return db.collection(collectionName).find(criteria).toArray();
+}
+
+function insertDocs(db, collectionName, docs) {
+    return db.collection(collectionName).insert(docs);
+}
+
+exports.getStickerAsync = id => {
+    return connect().then(db => {
+        return findDoc(db, stickerCollectionName, { id });
+    });
+};
+
+exports.getStickersAsync = (tags, itemIds) => {
+    return connect().then(db => {
+        const query = {};
+        if (tags) {
+            query.tags = {
+                $elemMatch: { $in: tags }
+            };
+        }
+
+        if (itemIds instanceof Array) {
+            query.id = { $in: itemIds };
+        } else if (typeof itemIds === "string") {
+            query.id = { $in: [itemIds] };
+        }
+
+        return findDocs(db, stickerCollectionName, query);
+    });
+}
+
+exports.addStickersAsync = items => {
+    return connect().then(async db => {
+        const result = await insertDocs(db, stickerCollectionName, items);
+        return result.ops;
+    });
+}
+
+exports.initializeDatabaseAsync = () => {
+    const initialData = require('./initial-data');
+    return connect()
+        .then(db => db.dropDatabase())
+        .then(() => exports.addStickersAsync(initialData))
+        .then(disconnect);
+}

--- a/stickerService/package.json
+++ b/stickerService/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "stickers",
+  "version": "1.0.0",
+  "description": "sticker service for demo app",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "body-parser": "^1.15.0",
+    "express": "^4.15.2",
+    "kafka-node": "^1.6.0",
+    "mongodb": "~2.1.14",
+    "pug": "^2.0.0-rc.1",
+    "redis": "^2.7.1",
+    "request": "^2.81.0",
+    "socket.io": "^1.7.3"
+  },
+  "devDependencies": {
+    "@types/express": "^4.0.35",
+    "@types/kafka-node": "^1.3.2",
+    "@types/mongodb": "^2.2.2",
+    "@types/redis": "^0.12.36",
+    "@types/socket.io": "^1.4.29"
+  }
+}

--- a/stickerService/routes/search.js
+++ b/stickerService/routes/search.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const crypto = require('crypto');
+const express = require('express');
+const request = require('request');
+const router = express.Router();
+
+const nobodyAuthorRegex = /nobody@flickr.com \((.*)\)/;
+
+// Note: we handle image search on the server side to demonstrate the application of microservices
+router.get('/', (req, res) => {
+    const keyword = req.query.keyword;
+
+    if (!keyword) {
+        console.warn('No keyword was specified; searching with \'undefined\'');
+    }
+
+    console.log('Handling /api/search. Keyword: ' + keyword);
+
+    const url = 'http://api.flickr.com/services/feeds/photos_public.gne?tags='
+        + keyword + '&format=json&jsoncallback=?';
+
+    request({ url, json: true }, (err, response, body) => {
+        if (!err && response.statusCode === 200) {
+            console.log('Flickr search succeeded with items:');
+            const items = cleanUpSearchResult(body);
+            console.log(items);
+            res.cookie('last-keyword', keyword, { expires: new Date(Date.now() + 900000) });
+            res.cookie('last-search-result-length', items.length);
+            res.send({
+                items: items
+            });
+        } else {
+            console.log('Flickr search failed');
+            const statusCodeBadRequest = 400;
+            res.status(statusCodeBadRequest).send({
+                items: []
+            });
+        }
+    });
+});
+
+// Clean up Flickr search result so that it can be parsed by JSON.parse() on client side
+function cleanUpSearchResult(data) {
+    // Remove the outer parenthesis
+    let result = data.slice(1, -1);
+
+    // Strip out single quotes in image descriptions which might confuse the JSON parser
+    result = result.replace(/\\'/g, '');
+
+    // Parse the results
+    result = JSON.parse(result);
+    return result.items.map((item) => {
+        const nobodyCheck = nobodyAuthorRegex.exec(item.author);
+        return {
+            id: crypto.createHash('md5')
+                .update(item.link)
+                .digest('hex'), // Kinda hacky, but at least unique and guaranteed to be consistent across searches
+            tags: item.tags.split(' '),
+            name: item.title,
+            description: item.description,
+            author: nobodyCheck ? nobodyCheck[1] : item.author,
+            size: {
+                width: '2in',
+                height: '2in'
+            },
+            image: item.media.m
+        };
+    });
+}
+
+module.exports = router;

--- a/stickerService/routes/stickers.js
+++ b/stickerService/routes/stickers.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const bodyParser = require('body-parser');
+const db = require('../mongodb');
+const router = require('express').Router();
+
+// Gets sticker details from the database, with
+// optional query parameters "tags" and "ids".
+router.get('/', async (req, res) => {
+    let tags;
+    if (req.query.tags) {
+        tags = req.query.tags.split(',');
+    }
+
+    try {
+        const stickers = await db.getStickersAsync(tags, req.query.ids);
+        res.send(stickers);
+    } catch (error) {
+        console.error(error);
+        res.sendStatus(500);
+    }
+});
+
+router.use(bodyParser.json());
+
+// Add a new sticker to the database.
+// If the sticker already exists, responds 400.
+router.post('/:item_id', async (req, res) => {
+    try {
+        const sticker = await db.getStickerAsync(req.params.item_id);
+        if (sticker) {
+            res.sendStatus(400);
+        } else {
+            const newItems = await db.addStickersAsync([req.body]);
+            res.send(newItems[0]);
+        }
+    } catch (error) {
+        console.error(error);
+        res.sendStatus(500);
+    }
+});
+
+module.exports = router;

--- a/stickerService/routes/test.js
+++ b/stickerService/routes/test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// Routes for sending Kafka messages representing checkout and view
+// events, for simulating client activity in development.
+
+const bodyParser = require('body-parser');
+const kafka = require('kafka-node');
+const router = require('express').Router();
+
+const producer = new kafka.HighLevelProducer(new kafka.Client(process.env.KAFKA_HOST));
+
+router.use(bodyParser.json());
+
+// emit a kafka message for a checkout event
+router.post('/checkout', (req, res) => {
+    // expect body to be shaped like a checkout object posted by the client
+    // e.g. { "checkout-items": { "sticker1": { "id": "sticker1", "quantity": 2 }, ..., }
+    const checkoutItems = req.body['checkout-items'];
+
+    const orderedStickers = Object.keys(checkoutItems).map(item => {
+        return {
+            item_id: checkoutItems[item].id,
+            quantity: checkoutItems[item].quantity
+        }
+    });
+
+    const payloads = [{
+        topic: process.env.KAFKA_TOPIC,
+        messages: JSON.stringify(orderedStickers)
+    }];
+    producer.send(payloads, (err, data) => {
+        if (err) {
+            res.status(500).json(err);
+        } else {
+            res.status(200).json(data);
+        }
+    });
+});
+
+// emit a Kafka message for a view event
+router.get('/view/:item_id', (req, res) => {
+    const message = JSON.stringify([{ item_id: req.params.item_id }]);
+    const payload = [{
+        topic: process.env.KAFKA_TOPIC,
+        messages: message
+    }];
+    producer.send(payload, (err, data) => {
+        if (err) {
+            res.status(500).json(err);
+        } else {
+            res.status(200).json(data);
+        }
+    });
+});
+
+module.exports = router;

--- a/stickerService/routes/top.js
+++ b/stickerService/routes/top.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const itemPopularity = require('../itemPopularity');
+const router = require('express').Router();
+
+// responds with the k most popular stickers, ordered by descending popularity
+router.get('/:k', async (req, res) => {
+    const k = parseInt(req.params.k);
+    if (!Number.isInteger(k) || k < 0) {
+        res.sendStatus(400);
+        return;
+    }
+
+    try {
+        const stickers = await itemPopularity.topKAsync(k);
+        res.send(stickers);
+    } catch (error) {
+        console.error(error);
+        res.sendStatus(500);
+    }
+});
+
+module.exports = router;

--- a/stickerService/test/index.html
+++ b/stickerService/test/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+  <head>
+    <title>socket test</title>
+  </head>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.7.3/socket.io.min.js"></script>
+  <script src="https://code.jquery.com/jquery-1.11.1.js"></script>
+  <script>
+    $(function () {
+    var socket = io();
+    socket.on('message', function(items) {
+      $('#items').append($('<li>').text(items));
+    });
+  });
+  </script>
+  <body>
+    <ol id="items"></ol>
+  </body>
+</html>


### PR DESCRIPTION
This service owns the mongodb sticker data. Other services can retrieve sticker records from its `/stickers` route, optionally filtering by ids and tags, and persist new stickers as well. Its `/search` route provides search results from the Flickr API.

Additionally, this service tracks sticker popularity trends. Here's the gist:
- Popularity scores reflect how often stickers are ordered or viewed.
  - The service monitors a Kafka topic to learn when stickers are ordered or viewed. (An order is worth 3 views.)
  - Scores are persisted in a Redis sorted set.
  - Every minute, all scores are reduced by 20%.
- The service publishes a list of the top 5 most popular stickers via websocket (socket.io).
  - Clients are sent the current top 5 when they connect.
  - Updates are sent only when the top 5 ranking changes.

Closes #14, #17, and #43.