### PR TITLE
'new' not needed when creating Router

### DIFF
--- a/server/routes/browse.js
+++ b/server/routes/browse.js
@@ -2,7 +2,7 @@
 
 const express = require('express');
 const bodyParser = require('body-parser');
-const router = new express.Router();
+const router = express.Router();
 
 const dataAccess = require('../db/data-access');
 const metadata = require('../middleware/metadata');

--- a/server/routes/cart.js
+++ b/server/routes/cart.js
@@ -4,7 +4,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const dataAccess = require('../db/data-access');
 
-const router = new express.Router();
+const router = express.Router();
 
 router.use(bodyParser.json());
 

--- a/server/routes/checkout.js
+++ b/server/routes/checkout.js
@@ -2,7 +2,7 @@
 
 const express = require('express');
 const bodyParser = require('body-parser');
-const router = new express.Router();
+const router = express.Router();
 
 const dataAccess = require('../db/data-access');
 

--- a/server/routes/create.js
+++ b/server/routes/create.js
@@ -3,7 +3,7 @@
 const crypto = require('crypto');
 const express = require('express');
 const request = require('request');
-const router = new express.Router();
+const router = express.Router();
 
 const nobodyAuthorRegex = /nobody@flickr.com \((.*)\)/;
 

--- a/server/routes/feedback.js
+++ b/server/routes/feedback.js
@@ -2,7 +2,7 @@
 
 const express = require('express');
 const bodyParser = require('body-parser');
-const router = new express.Router();
+const router = express.Router();
 
 const dataAccess = require('../db/data-access');
 


### PR DESCRIPTION
There is no need to `new` an express Router.  While the code works fine as-is, it gets flagged as an error when using TypeScript's new JavaScript error checking support in TS 2.3.1.