### PR TITLE
Use ASP.NET Core MVC model validation in checkout service

### DIFF
--- a/apigateway/routes/checkout.js
+++ b/apigateway/routes/checkout.js
@@ -11,35 +11,38 @@ const router = express.Router();
 const bodyParser = require('body-parser');
 router.use(bodyParser.urlencoded({ extended: true }));
 
-router.post('/', function stickerRouteCheckout(req, res) {
-    var orderJson = {
+router.post('/', (req, res) => {
+    var order = {
         Id: guid.raw(),
+        UserId: req.user.id,
         FullName: req.body['checkout-name'],
         Email: req.body['checkout-email'],
         Items: req.body['checkout-items']
     };
 
-    request({
+    request.post({
         url: checkoutServiceUrl + '/api/order/',
-        method: 'POST',
         json: true,
-        body: orderJson,
-        headers: {
-            //Pass the current authenticated user's id to the checkout microservice
-            'stickerUserId': req.user.id
-        }
-    }, function finishAddOrder(error) {
+        body: order
+    }, (error, response) => {
         if (error) {
-            console.log('Adding Order failed: ' + error);
+            console.error(`Could not reach checkout service: ${error}`);
             res.sendStatus(500);
+        } else if (response.statusCode > 201) {
+            // TODO ASP.NET Core describes model validation errors in its
+            // response, which we could surface in the client
+            console.log(`Order rejected by checkout service: ${JSON.stringify(response.body)}`);
+            res.sendStatus(400);
         } else {
             console.log('Order added');
+
+            // checkout succeeded, empty the cart
             request.delete({
                 url: `${process.env.SESSION_SERVICE_URL}/cart`,
-                headers: { 'stickerUserId': req.user.id }
+                headers: { stickerUserId: req.user.id }
             }, (error, response) => {
                 if (error) {
-                    console.error(error);
+                    console.error(`Could not reach session service: ${error}`);
                 }
                 res.render('index', { pageTitle: 'Checkout', entry: 'checkout' });
             });

--- a/checkoutService/Controllers/OrderController.cs
+++ b/checkoutService/Controllers/OrderController.cs
@@ -54,20 +54,11 @@ namespace CheckoutService.Controllers
         [HttpPost]
         public async Task<IActionResult> Create([FromBody] Order order)
         {
-            StringValues userId = String.Empty;
-            if (order == null || !this.Request.Headers.TryGetValue("stickerUserId", out userId))
+            if (!ModelState.IsValid)
             {
-                return BadRequest($"Invalid order values. Order:{order} UserId:{userId}");
+                return BadRequest(ModelState);
             }
 
-            //When an Order is created, the service assumes that any Items that should be added to the order will be sent
-            //in the same POST request.  If no items are specified, an empty list of Items will be created by default.
-            if (order.Items == null)
-            {
-                order.Items = new List<OrderItem>();
-            }
-
-            order.UserId = userId;
             await _database.GetOrderCollection().InsertOneAsync(order);
 
             // produce a Kafka record so the sticker service can update popularity scores

--- a/checkoutService/Models/Order.cs
+++ b/checkoutService/Models/Order.cs
@@ -13,12 +13,17 @@ namespace CheckoutService.Models
         [Required]
         public string UserId {get; set;}
 
-        [Required]
+        // the client will send an empty name when none is provided
+        // in the user's profile, which is possible because a name
+        // needn't be provided at signup
+        [Required(AllowEmptyStrings = true)]
         public string FullName {get; set;}
 
         [Required]
+        [DataType(DataType.EmailAddress)]
         public string Email {get; set;}
 
+        [Required]
         public IList<OrderItem> Items {get; set;}
     }
 }


### PR DESCRIPTION
I observed orders failing because I signed up with an empty name. Here are a few changes in response:
- `apigateway`
  - distinguish checkout failures due to network failure from those due to invalid data (`request` doesn't consider an HTTP error code an error)
  - POST JSON to `checkoutService` which conforms to that service's models
- `checkoutService`
  - use Core MVC's model validation on POSTed orders
  - allow empty `Order.FullName`, because a valid user profile may have an empty name