### PR TITLE
Use new init container syntax

### DIFF
--- a/k8s/stickerapp/templates/session-deployment.yaml
+++ b/k8s/stickerapp/templates/session-deployment.yaml
@@ -8,20 +8,6 @@ spec:
       labels:
         component: session
 {{ include "stickerapp.common.labels" . | indent 8 }}
-      annotations:
-        # using beta syntax until new ACS clusters are k8s 1.6 (they're 1.5.3 at time of writing)
-        # this init container polls the sticker service for 13 minutes, completing successfully when something is listening
-        pod.beta.kubernetes.io/init-containers: '[
-            {
-              "name": "sticker-service-poll",
-              "image": "alpine:3.6",
-              "imagePullPolicy": "IfNotPresent",
-              "command": [
-                "sh", "-c",
-                "for i in $(seq 1 60); do nc -z -w3 {{printf "%s-stickers" .Release.Name}} 80 && exit 0 || sleep 10s; done; exit 1"
-              ]
-            }
-        ]'
     spec:
       containers:
       - name: "{{.Release.Name}}-session"
@@ -39,5 +25,11 @@ spec:
           value: "http://{{.Release.Name}}-stickers"
         ports:
         - containerPort: 8080
+      initContainers:
+        # poll the sticker service for 13 minutes, complete when something is listening
+      - name: sticker-service-poll
+        image: alpine:3.6
+        command: [ "sh", "-c",
+                   "for i in $(seq 1 60); do nc -z -w3 {{printf "%s-stickers" .Release.Name}} 80 && exit 0 || sleep 10s; done; exit 1" ]
       imagePullSecrets:
       - name: "{{ template "registry.secret.name" . }}"

--- a/k8s/stickerapp/templates/stickers-deployment.yaml
+++ b/k8s/stickerapp/templates/stickers-deployment.yaml
@@ -8,41 +8,6 @@ spec:
       labels:
         component: stickers
 {{ include "stickerapp.common.labels" . | indent 8 }}
-      annotations:
-        # using beta syntax until new ACS clusters are k8s 1.6 (they're 1.5.3 at time of writing)
-        pod.beta.kubernetes.io/init-containers: '[
-            {
-              "name": "init-kafka",
-              "image": "solsson/kafka-topic-client",
-              "imagePullPolicy": "IfNotPresent",
-              "command": [
-                "sh", "-c",
-                "for i in $(seq 1 60); do java -jar kafka-topic-client.jar && exit 0 || sleep 10s; done; exit 1"
-              ],
-              "env": [
-                {
-                  "name": "ZOOKEEPER_CONNECT",
-                  "value": "{{ template "zookeeper.service.name" . }}"
-                },
-                {
-                  "name": "TOPIC_NAME",
-                  "value": "{{ template "kafka.topic" . }}"
-                }
-              ]
-            },
-            {
-              "name": "init-db",
-              "image": "{{ template "registry.name" . }}stickerapp/stickers:v1",
-              "imagePullPolicy": "{{.Values.imagePullPolicy}}",
-              "command": ["node", "init-db.js"],
-              "env": [
-                {
-                  "name": "MONGO_URL",
-                  "value": "{{ template "mongo.connectionString" .}}"
-                }
-              ]
-            }
-        ]'
     spec:
       containers:
       - name: "{{.Release.Name}}-stickers"
@@ -60,5 +25,22 @@ spec:
 {{ include "redis-env" . | indent 8 }}
         ports:
         - containerPort: 8080
+      initContainers:
+      - name: init-kafka
+        image: solsson/kafka-topic-client
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c", "for i in $(seq 1 60); do java -jar kafka-topic-client.jar && exit 0 || sleep 10s; done; exit 1"]
+        env:
+        - name: ZOOKEEPER_CONNECT
+          value: "{{ template "zookeeper.service.name" . }}"
+        - name: TOPIC_NAME
+          value: "{{ template "kafka.topic" . }}"
+      - name: init-db
+        image: "{{ template "registry.name" . }}stickerapp/stickers:v1"
+        imagePullPolicy: "{{.Values.imagePullPolicy}}"
+        command: ["node", "init-db.js"]
+        env:
+        - name: MONGO_URL
+          value: "{{ template "mongo.connectionString" .}}"
       imagePullSecrets:
       - name: "{{ template "registry.secret.name" . }}"


### PR DESCRIPTION
We can stop using the beta annotation syntax because ACS now deploys Kubernetes 1.6.2.