### PR TITLE
Simplify chart for CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,58 +19,95 @@ simplify deploying the application.
 * A Kubernetes cluster. Follow the Azure Container Service [walkthrough](
   https://docs.microsoft.com/en-us/azure/container-service/container-service-kubernetes-walkthrough)
   to create one.
-  * This chart does not work with `minikube` due to persistent volume permission
-    issues ([minikube #956](https://github.com/kubernetes/minikube/issues/956)).
-* The Helm client on your local machine, and Tiller installed on your cluster.
-  See the [Helm quickstart guide](https://docs.helm.sh/using-helm) for instructions.
 
-#### Installing the chart
-1. Build the app's images and push them to your registry. The chart expects these
+#### Preparing your local machine
+* Ensure `kubectl` is configured for your cluster, and that the Helm
+ client is on your path. See the [Helm quickstart guide](https://docs.helm.sh/using-helm)
+ for instructions.
+
+* Build the app's React client. From the repository root:
+  ```console
+  $ docker-compose -f docker-compose.build-client.yml up
+  ```
+
+#### Building and pushing the app's images
+The chart expects these
 images, where `your-registry.azurecr.io` is your private registry:
 
-    image name | source directory
-    --- | ---
-    your-registry.azurecr.io/stickerapp/apigateway:v1 | apigateway
-    your-registry.azurecr.io/stickerapp/checkout:v1 | checkoutService
-    your-registry.azurecr.io/stickerapp/session:v1 | sessionService
-    your-registry.azurecr.io/stickerapp/stickers:v1 | stickerService
+image name | source directory
+--- | ---
+`your-registry.azurecr.io/stickerapp/apigateway:1.0` | apigateway
+`your-registry.azurecr.io/stickerapp/checkout:1.0` | checkoutService
+`your-registry.azurecr.io/stickerapp/session:1.0` | sessionService
+`your-registry.azurecr.io/stickerapp/stickers:1.0` | stickerService
 
-  You can build these from the command line, e.g. for the sticker service:
-  ```
-  $ docker login your-registry.azurecr.io -u adminName -p password
-  $ cd stickerService
-  $ docker build -t your-registry.azurecr.io/stickerapp/stickers:v1 .
-  $ docker push your-registry.azurecr.io/stickerapp/stickers:v1
-  ```
-2. Open a command prompt to the `k8s` directory.
-1. Generate docker configuration with the provided script:
-```
-$ node generate-dockercfg.js
-```
-
-4. Edit `values.yaml`. Populate the `dockercfg` field with the script's output,
-and the `registry` field with your registry's url, e.g. `your-registry.azurecr.io`.
-
-1. Add the Incubator repo to Helm:
-```
-$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
-```
-
-6. Collect the chart's dependencies:
-```
-$ helm dependency update stickerapp
-```
-
-7. Install the chart:
+The chart's `imageTag` value is used for these images. It defaults to `1.0` and
+ can be overridden. You can build and push the images from the command line, e.g.
+ for the sticker service:
 ```console
-$ helm install stickerapp
-NAME:   honest-deer
- ...
+$ docker login your-registry.azurecr.io -u adminName -p password
+$ cd stickerService
+$ docker build -t your-registry.azurecr.io/stickerapp/stickers:1.0 .
+$ docker push your-registry.azurecr.io/stickerapp/stickers:1.0
 ```
+
+#### Preparing your Kubernetes cluster
+* Install Tiller, Helm's server-side component:
+  ```console
+  $ helm init
+  ```
+* Deploy an ingress controller, if your cluster doesn't have one already:
+  ```console
+  $ helm install -f nginx-ingress-values.yaml --namespace kube-system stable/nginx-ingress
+  ```
+  * `nginx-ingress-values.yaml`, in this repository's `k8s` directory, contains
+ settings which override the `nginx-ingress` chart's defaults to disable SSL
+ redirecting and use a more recent controller image
+
+* The app requires a Kafka cluster. You can deploy a small one with Helm:
+  ```console
+  $ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+  $ helm install -n kafka --set Replicas=1 --set zookeeper.Servers=1 --set zookeeper.Storage="1Gi" incubator/kafka
+  ```
+
+#### Installing the chart
+1. Open a shell in the `k8s` directory.
+1. Generate the docker-registry secret Kubernetes will use to pull the app's
+ images. The included script can do this:
+    ```console
+    $ node generate-dockercfg.js
+    ```
+
+1. Set required values in `values.yaml` (you can provide these on the command
+ line with `--set` instead, if you don't mind a very long command line)
+
+    required value | description
+    --- | ---
+    `azureActiveDirectory.clientId` | client ID for your Azure AD app
+    `azureActiveDirectory.clientSecret` | secret for your Azure AD app
+    `azureActiveDirectory.destroySessionUrl` | URL used to end AAD session
+    `azureActiveDirectory.redirectUrl` | post-login redirect URL
+    `azureActiveDirectory.tenant` | Azure AD tenant
+    `registry` | Docker registry, e.g. `your-registry.azurecr.io`
+    `dockercfg` | docker-registry secret
+    `kafkaBroker` | DNS name and port of a Kafka broker
+    `zookeeperConnect` | DNS name and port of a ZooKeeper instance
+
+5. Collect the chart's dependencies:
+    ```console
+    $ helm dependency update stickerapp
+    ```
+
+1. Install the chart:
+    ```console
+    $ helm install stickerapp
+    NAME:   honest-deer
+    ...
+    ```
 
 #### Verifying the deployment
 You can inspect the deployment with the Kubernetes UI, `helm`, or `kubectl`:
- ```console
+```console
 $ helm status honest-deer
 LAST DEPLOYED: Mon Jun  5 15:00:38 2017
 NAMESPACE: default
@@ -79,7 +116,7 @@ STATUS: DEPLOYED
 RESOURCES:
  ...
 
-$ kubectl get all -l app=stickerapp
+$ kubectl get all -l release=honest-deer
 NAME                                         READY     STATUS    RESTARTS   AGE
 po/honest-deer-apigateway-1160103434-9q3vr   1/1       Running   0          7m
 po/honest-deer-checkout-545275974-f2rt5      1/1       Running   0          7m
@@ -87,17 +124,17 @@ po/honest-deer-session-1173111989-x7x37      1/1       Running   0          7m
  ...
 ```
 
-The deployment will take several minutes. When it completes, the app's API gateway
-will be exposed at a public IP. You can retrieve this IP from the Kubernetes UI,
-or `kubectl`:
+The app is reachable through the ingress controller's external IP address. To
+ find this, inspect the ingress controller's service in the Kubernetes UI,
+ or use `kubectl`. For example, for an ingress controller deployed as described above:
 ```console
-$ kubectl get svc -l=component=apigateway
-NAME                       CLUSTER-IP     EXTERNAL-IP      PORT(S)             AGE
-honest-deer-apigateway     10.0.193.70    40.112.209.189   80:32517/TCP        7m
+$ kubectl get svc -l app=nginx-ingress --namespace kube-system
+NAME                                            CLUSTER-IP     EXTERNAL-IP     PORT(S)                      AGE
+awesome-narwhal-nginx-ingress-controller        10.0.190.16    52.173.17.217   80:32493/TCP,443:31437/TCP   40m
 ```
 
 #### Modifying the running app
-Like any other Kubernetes app, you can control this one with `kubectl`. For
+Like any Kubernetes app, you can control this one with `kubectl`. For
 example, scaling the `apigateway` deployment to add a second pod:
 ```
 $ kubectl get deploy -l component=apigateway
@@ -105,7 +142,7 @@ NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 honest-deer-apigateway   1         1         1            1           9m
 $ kubectl scale --replicas=2 deploy/honest-deer-apigateway
 deployment "honest-deer-apigateway" scaled
-$ kubectl get deploy -l=component=apigateway
+$ kubectl get deploy -l component=apigateway
 NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 honest-deer-apigateway   2         2         2            2           10m
 ```

--- a/k8s/generate-dockercfg.js
+++ b/k8s/generate-dockercfg.js
@@ -5,16 +5,15 @@ const rl = readline.createInterface({
     output: process.stdout
 });
 
-rl.question('registry name: ', registryName => {
+rl.question('registry (e.g. my-registry.azurecr.io): ', registry => {
     rl.question('username: ', username => {
         rl.question('password: ', password => {
-            dockercfg = {
-                registryName: {
-                    username,
-                    password,
-                    email: 'unused@acr.io',
-                    auth: new Buffer(`${username}:${password}`).toString('base64')
-                }
+            let dockercfg = {};
+            dockercfg[registry] = {
+                username,
+                password,
+                email: 'unused@acr.io',
+                auth: new Buffer(`${username}:${password}`).toString('base64')
             }
 
             const json = JSON.stringify(dockercfg);

--- a/k8s/nginx-ingress-values.yaml
+++ b/k8s/nginx-ingress-values.yaml
@@ -1,0 +1,6 @@
+controller:
+  config:
+    hsts: "false"
+    ssl-redirect: "false"
+  image:
+    tag: "0.9.0-beta.7"

--- a/k8s/stickerapp/requirements.yaml
+++ b/k8s/stickerapp/requirements.yaml
@@ -1,7 +1,4 @@
 dependencies:
-  - name: kafka
-    version: 0.1.2
-    repository: http://storage.googleapis.com/kubernetes-charts-incubator
   - name: mongodb
     version: 0.4.10
     repository: https://kubernetes-charts.storage.googleapis.com/

--- a/k8s/stickerapp/templates/_helpers.tpl
+++ b/k8s/stickerapp/templates/_helpers.tpl
@@ -9,12 +9,9 @@ release: "{{ .Release.Name }}"
 {{- printf "%s-adb2c-secrets" .Release.Name | trunc 24 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "kafka.broker" -}}
-{{- printf "%s-broker-kf" .Release.Name -}}
-{{- end -}}
-
 {{- define "kafka.topic" -}}
-{{- default "sticker-popularity" .Values.kafkaTopic -}}
+{{- $name := default "sticker-activity" .Values.kafkaTopic }}
+{{- printf "%s-%s" .Release.Name $name -}}
 {{- end -}}
 
 {{- define "mongo.connectionString" -}}
@@ -49,8 +46,4 @@ release: "{{ .Release.Name }}"
 
 {{- define "registry.secret.name" -}}
 {{- printf "%s-stickerapp-registry-secret" .Release.Name -}}
-{{- end -}}
-
-{{- define "zookeeper.service.name" -}}
-{{- printf "%s-zookeeper-zk" .Release.Name -}}
 {{- end -}}

--- a/k8s/stickerapp/templates/apigateway-deployment.yaml
+++ b/k8s/stickerapp/templates/apigateway-deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: "{{.Release.Name}}-apigateway"
-        image: "{{ template "registry.name" . }}stickerapp/apigateway:v1"
+        image: "{{ template "registry.name" . }}stickerapp/apigateway:{{.Values.imageTag}}"
         imagePullPolicy: "{{.Values.imagePullPolicy}}"
         env:
         - name: AD_CLIENT_ID

--- a/k8s/stickerapp/templates/apigateway-ingress.yaml
+++ b/k8s/stickerapp/templates/apigateway-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "{{ printf "%s-ingress" .Release.Name }}"
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  labels:
+{{ include "stickerapp.common.labels" . | indent 4 }}
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        backend:
+          serviceName: "{{.Release.Name}}-apigateway"
+          servicePort: 80

--- a/k8s/stickerapp/templates/checkout-deployment.yaml
+++ b/k8s/stickerapp/templates/checkout-deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: "{{.Release.Name}}-checkout"
-        image: "{{ template "registry.name" . }}stickerapp/checkout:v1"
+        image: "{{ template "registry.name" . }}stickerapp/checkout:{{.Values.imageTag}}"
         imagePullPolicy: "{{.Values.imagePullPolicy}}"
         env:
         - name: ASPNETCORE_ENVIRONMENT

--- a/k8s/stickerapp/templates/checkout-deployment.yaml
+++ b/k8s/stickerapp/templates/checkout-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - name: MongoDb__FeedbackCollectionName
           value: feedbackEntries
         - name: Kafka__Broker
-          value: "{{ template "kafka.broker" . }}"
+          value: "{{ .Values.kafkaBroker }}"
         - name: Kafka__Topic
           value: "{{ template "kafka.topic" . }}"
         ports:

--- a/k8s/stickerapp/templates/services.yaml
+++ b/k8s/stickerapp/templates/services.yaml
@@ -6,7 +6,7 @@ metadata:
 {{ include "stickerapp.common.labels" . | indent 4 }}
   name: "{{.Release.Name}}-apigateway"
 spec:
-  type: LoadBalancer
+  type: NodePort
   ports:
   - port: 80
     targetPort: 8080

--- a/k8s/stickerapp/templates/session-deployment.yaml
+++ b/k8s/stickerapp/templates/session-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         image: "{{ template "registry.name" . }}stickerapp/session:v1"
         imagePullPolicy: "{{.Values.imagePullPolicy}}"
         env:
-        - name: KAFKA_HOST
+        - name: KAFKA_BROKER
           value: "{{ .Values.kafkaBroker }}"
         - name: KAFKA_TOPIC
           value: "{{ template "kafka.topic" . }}"

--- a/k8s/stickerapp/templates/session-deployment.yaml
+++ b/k8s/stickerapp/templates/session-deployment.yaml
@@ -15,7 +15,7 @@ spec:
         imagePullPolicy: "{{.Values.imagePullPolicy}}"
         env:
         - name: KAFKA_HOST
-          value: "{{ template "zookeeper.service.name" . }}"
+          value: "{{ .Values.kafkaBroker }}"
         - name: KAFKA_TOPIC
           value: "{{ template "kafka.topic" . }}"
         - name: NODE_ENV

--- a/k8s/stickerapp/templates/session-deployment.yaml
+++ b/k8s/stickerapp/templates/session-deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: "{{.Release.Name}}-session"
-        image: "{{ template "registry.name" . }}stickerapp/session:v1"
+        image: "{{ template "registry.name" . }}stickerapp/session:{{.Values.imageTag}}"
         imagePullPolicy: "{{.Values.imagePullPolicy}}"
         env:
         - name: KAFKA_BROKER

--- a/k8s/stickerapp/templates/stickers-deployment.yaml
+++ b/k8s/stickerapp/templates/stickers-deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: "{{.Release.Name}}-stickers"
-        image: "{{ template "registry.name" . }}stickerapp/stickers:v1"
+        image: "{{ template "registry.name" . }}stickerapp/stickers:{{.Values.imageTag}}"
         imagePullPolicy: "{{.Values.imagePullPolicy}}"
         env:
         - name: KAFKA_BROKER
@@ -36,7 +36,7 @@ spec:
         - name: TOPIC_NAME
           value: "{{ template "kafka.topic" . }}"
       - name: init-db
-        image: "{{ template "registry.name" . }}stickerapp/stickers:v1"
+        image: "{{ template "registry.name" . }}stickerapp/stickers:{{.Values.imageTag}}"
         imagePullPolicy: "{{.Values.imagePullPolicy}}"
         command: ["node", "init-db.js"]
         env:

--- a/k8s/stickerapp/templates/stickers-deployment.yaml
+++ b/k8s/stickerapp/templates/stickers-deployment.yaml
@@ -15,7 +15,7 @@ spec:
         imagePullPolicy: "{{.Values.imagePullPolicy}}"
         env:
         - name: KAFKA_HOST
-          value: "{{ template "kafka.broker" . }}:9092"
+          value: "{{ .Values.kafkaBroker }}"
         - name: KAFKA_TOPIC
           value: "{{ template "kafka.topic" . }}"
         - name: MONGO_URL
@@ -32,7 +32,7 @@ spec:
         command: ["sh", "-c", "for i in $(seq 1 60); do java -jar kafka-topic-client.jar && exit 0 || sleep 10s; done; exit 1"]
         env:
         - name: ZOOKEEPER_CONNECT
-          value: "{{ template "zookeeper.service.name" . }}"
+          value: "{{ .Values.zookeeperConnect }}"
         - name: TOPIC_NAME
           value: "{{ template "kafka.topic" . }}"
       - name: init-db

--- a/k8s/stickerapp/templates/stickers-deployment.yaml
+++ b/k8s/stickerapp/templates/stickers-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         image: "{{ template "registry.name" . }}stickerapp/stickers:v1"
         imagePullPolicy: "{{.Values.imagePullPolicy}}"
         env:
-        - name: KAFKA_HOST
+        - name: KAFKA_BROKER
           value: "{{ .Values.kafkaBroker }}"
         - name: KAFKA_TOPIC
           value: "{{ template "kafka.topic" . }}"

--- a/k8s/stickerapp/values.yaml
+++ b/k8s/stickerapp/values.yaml
@@ -13,6 +13,12 @@ registry: ""
 # It can be generated with generate-dockercfg.js.
 dockercfg: ""
 
+# kafkaBroker is the DNS name of a kafka broker with port, e.g. "kafka:9092"
+kafkaBroker: ""
+
+# zookeeperConnect is the DNS name of a zookeeper instance with port, e.g. "zookeeper:2181"
+zookeeperConnect: ""
+
 # By default, this chart will deploy the below charts to your cluster.
 # To instead use an external service, set its value false and provide its required values below.
 local:
@@ -34,16 +40,6 @@ redisPassword: ""
 imagePullPolicy: "IfNotPresent"
 
 # subchart values
-kafka:
-  Replicas: 1
-  Memory: "512Mi"
-  ImagePullPolicy: "IfNotPresent"
-  zookeeper:
-    ImagePullPolicy: "IfNotPresent"
-    Servers: 1
-    Memory: "1Gi"
-    Storage: "1Gi"
-
 mongodb:
   persistence:
     enabled: false

--- a/k8s/stickerapp/values.yaml
+++ b/k8s/stickerapp/values.yaml
@@ -19,6 +19,9 @@ kafkaBroker: ""
 # zookeeperConnect is the DNS name of a zookeeper instance with port, e.g. "zookeeper:2181"
 zookeeperConnect: ""
 
+# the same tag is applied to all the app's images
+imageTag: "1.0"
+
 # By default, this chart will deploy the below charts to your cluster.
 # To instead use an external service, set its value false and provide its required values below.
 local:

--- a/sessionService/debug.env
+++ b/sessionService/debug.env
@@ -1,4 +1,4 @@
-KAFKA_HOST=kafka:9092
+KAFKA_BROKER=kafka:9092
 KAFKA_TOPIC=TrendingStickers
 NODE_ENV=development
 PORT=4000

--- a/sessionService/debug.env
+++ b/sessionService/debug.env
@@ -1,4 +1,4 @@
-KAFKA_HOST=zookeeper:2181
+KAFKA_HOST=kafka:9092
 KAFKA_TOPIC=TrendingStickers
 NODE_ENV=development
 PORT=4000

--- a/sessionService/package.json
+++ b/sessionService/package.json
@@ -9,13 +9,12 @@
   "dependencies": {
     "body-parser": "^1.15.0",
     "express": "^4.15.2",
-    "kafka-node": "^1.6.0",
+    "no-kafka": "^3.1.8",
     "redis": "^2.7.1",
     "request": "^2.81.0"
   },
   "devDependencies": {
     "@types/express": "^4.0.35",
-    "@types/kafka-node": "^1.3.2",
     "@types/redis": "^0.12.36",
     "@types/request": "^0.0.42"
   }

--- a/sessionService/routes/history.js
+++ b/sessionService/routes/history.js
@@ -1,16 +1,13 @@
 'use strict';
 
 const dataAccess = require('../data');
-const kafka = require('kafka-node');
+const kafka = require('no-kafka');
 const router = require('express').Router();
 
 // this producer publishes a stream of browsing events
 // the sticker service uses to calculate sticker popularity
-const kafkaProducer = new kafka.Producer(new kafka.Client(process.env.KAFKA_HOST));
-kafkaProducer.on('ready', () => console.log('kafka producer ready'));
-kafkaProducer.on('error', error => {
-    console.error('kafka producer error', error);
-});
+const kafkaProducer = new kafka.Producer({ connectionString: process.env.KAFKA_HOST });
+kafkaProducer.init().then(() => console.log('kafka producer ready'));
 
 // get recently viewed items
 router.get('/', async (req, res) => {
@@ -26,21 +23,17 @@ router.get('/', async (req, res) => {
 // record a new history entry
 router.put('/:item_id', async (req, res) => {
     console.log(`user ${req.userId} viewed ${req.params.item_id}`);
+
     // send a Kafka message to inform the sticker service of the view event
-    const payload = [{
-        topic: process.env.KAFKA_TOPIC,
-        partition: 0,
-        messages: JSON.stringify([{ id: req.params.item_id }])
-    }];
-    kafkaProducer.send(payload, (error, result) => {
-        if (error) {
-            // only log errors because failure doesn't affect this service's
-            // core purpose (also the reason not to wait for the callback)
-            console.error('Kafka send failed', error);
-        } else {
-            console.log('Kafka send succeeded', result);
-        }
-    });
+    try {
+        await kafkaProducer.send({
+            topic: process.env.KAFKA_TOPIC,
+            partition: 0,
+            message: { value: JSON.stringify([{ id: req.params.item_id }]) }
+        });
+    } catch (error) {
+        console.error('error sending kafka message', error);
+    }
 
     try {
         const history = await dataAccess.addItemToHistoryAsync(req.userId, req.params.item_id);

--- a/sessionService/routes/history.js
+++ b/sessionService/routes/history.js
@@ -6,7 +6,7 @@ const router = require('express').Router();
 
 // this producer publishes a stream of browsing events
 // the sticker service uses to calculate sticker popularity
-const kafkaProducer = new kafka.Producer({ connectionString: process.env.KAFKA_HOST });
+const kafkaProducer = new kafka.Producer({ connectionString: process.env.KAFKA_BROKER });
 kafkaProducer.init().then(() => console.log('kafka producer ready'));
 
 // get recently viewed items

--- a/stickerService/debug.env
+++ b/stickerService/debug.env
@@ -1,4 +1,4 @@
-KAFKA_HOST=kafka:9092
+KAFKA_BROKER=kafka:9092
 KAFKA_TOPIC=TrendingStickers
 MONGO_URL=mongodb://mongo:27017/getStickersDemo
 NODE_ENV=development

--- a/stickerService/itemPopularity.js
+++ b/stickerService/itemPopularity.js
@@ -158,7 +158,7 @@ const messageHandler = messageSet => {
     });
 };
 
-const consumer = new kafka.SimpleConsumer({ connectionString: process.env.KAFKA_HOST });
+const consumer = new kafka.SimpleConsumer({ connectionString: process.env.KAFKA_BROKER });
 consumer.init()
     .then(async () => {
         if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
This effects the changes we discussed to create a stable IP for the deployed app and enable `helm upgrade`:
* Kafka and ZooKeeper dependencies are now external to the chart. They can still be installed with Helm (documented in `README`).
* Added an ingress resource for `apigateway`. Assuming a properly configured ingress controller, this exposes the sticker app at the controller's external IP, which persists across the app's releases.
  * There's a suitable chart for an nginx ingress controller, modulo some configuration changes (documented in `README`).