### PR TITLE
Ensure a stable redis password

### DIFF
--- a/k8s/stickerapp/values.yaml
+++ b/k8s/stickerapp/values.yaml
@@ -54,5 +54,6 @@ mysql:
     enabled: false
 
 redis:
+  redisPassword: "password"
   persistence:
     enabled: false


### PR DESCRIPTION
The redis chart we depend on generates a random password when one isn't specified. This is a problem when we `helm upgrade` our chart, because every time that default password template is evaluated, a new password is generated, and Helm and k8s dutifully update the redis secret's value.

A typical upgrade results in a new generation of our app's pods, which will receive the newly-generated password. However, a typical upgrade doesn't necessitate a new redis pod, so the extant one--expecting the prior password--lives on, rejecting connections from our app's new pods.