### PR TITLE
Multi-stage Dockerfile for checkout service

### DIFF
--- a/checkoutService/Dockerfile
+++ b/checkoutService/Dockerfile
@@ -1,13 +1,11 @@
-FROM microsoft/dotnet:1.1.2-sdk
-WORKDIR /app
-
-# copy csproj and restore as distinct layers
-COPY CheckoutService.csproj ./
+FROM microsoft/aspnetcore-build:1.1.4 AS builder
+WORKDIR /build
+COPY . .
 RUN dotnet restore
+RUN dotnet publish -c Release -o /publish-output
 
-# copy and build everything else
-COPY . ./
-RUN dotnet publish -c Release -o out
-
-CMD ["dotnet", "out/CheckoutService.dll", "--server.urls", "http://*:5000"]
+FROM microsoft/aspnetcore:1.1.4
+WORKDIR /app
+COPY --from=builder /publish-output .
+CMD ["dotnet", "CheckoutService.dll"]
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -48,6 +48,7 @@ services:
     - 5000:5000
     environment:
       ASPNETCORE_ENVIRONMENT: dev
+      ASPNETCORE_URLS: "http://*:5000"
     links:
     - mongo
 


### PR DESCRIPTION
The Dockerfile for the checkout service runs `dotnet restore` then indiscriminately copies the build context. If there are restore assets in the build context, they overwrite those in the prior layer, causing the subsequent publish to fail because they reference paths on the local filesystem.

This change cleans up the Dockerfile with a multi-stage build, solving this problem and producing a leaner final image.

Fixes #67